### PR TITLE
Move strings to actual structure to keep in PROGMEM

### DIFF
--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -36,31 +36,31 @@ PROGMEM static const struct chipinfo {
 	uint32_t chipsize;	// total number of bytes in the chip
 	uint32_t progtime;	// maximum microseconds to wait for page programming
 	uint32_t erasetime;	// maximum microseconds to wait for sector erase
-	const char *pn;		//flash name
+	const char pn[22];		//flash name
 } known_chips[] = {
-{{0xEF, 0x40, 0x15}, 24, 256, 32768, 0x52, 2097152, 3000, 1600000, (const char*)F("W25Q16JV*Q/W25Q16FV")},  // Winbond W25Q16JV*Q/W25Q16FV
-{{0xEF, 0x40, 0x16}, 24, 256, 32768, 0x52, 4194304, 3000, 1600000, (const char*)F("W25Q32JV*Q/W25Q32FV")},  // Winbond W25Q32JV*Q/W25Q32FV
-{{0xEF, 0x40, 0x17}, 24, 256, 65536, 0xD8, 8388608, 3000, 2000000, (const char*)F("W25Q64JV*Q/W25Q64FV")},  // Winbond W25Q64JV*Q/W25Q64FV
-{{0xEF, 0x40, 0x18}, 24, 256, 65536, 0xD8, 16777216, 3000, 2000000, (const char*)F("W25Q128JV*Q/W25Q128FV")}, // Winbond W25Q128JV*Q/W25Q128FV
-{{0xEF, 0x40, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, (const char*)F("W25Q256JV*Q")}, // Winbond W25Q256JV*Q
-{{0xEF, 0x40, 0x20}, 32, 256, 65536, 0xDC, 67108864, 3500, 2000000, (const char*)F("W25Q512JV*Q")}, // Winbond W25Q512JV*Q
-{{0xEF, 0x40, 0x21}, 32, 256, 65536, 0xDC, 134217728, 3500, 2000000, (const char*)F("W25Q01JV*Q")},// Winbond W25Q01JV*Q
-{{0xEF, 0x70, 0x17}, 24, 256, 65536, 0xD8, 8388608, 3000, 2000000, (const char*)F("W25Q64JV*M (DTR)")},  // Winbond W25Q64JV*M (DTR)
-{{0xEF, 0x70, 0x18}, 24, 256, 65536, 0xD8, 16777216, 3000, 2000000, (const char*)F("W25Q128JV*M (DTR)")}, // Winbond W25Q128JV*M (DTR)
-{{0xEF, 0x70, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, (const char*)F("W25Q256JV*M (DTR)")}, // Winbond W25Q256JV*M (DTR)
-{{0xEF, 0x80, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, (const char*)F("W25Q256JW*M")}, // Winbond (W25Q256JW*M)
-{{0xEF, 0x70, 0x20}, 32, 256, 65536, 0xDC, 67108864, 3500, 2000000, (const char*)F("W25Q512JV*M (DTR)")}, // Winbond W25Q512JV*M (DTR)
-{{0x1F, 0x84, 0x01}, 24, 256,  4096, 0x20, 524288, 2500, 300000, (const char*)F("AT25SF041")},    // Adesto/Atmel AT25SF041
-{{0x01, 0x40, 0x14}, 24, 256,  4096, 0x20, 1048576, 5000, 300000, (const char*)F("S25FL208K")},   // Spansion S25FL208K
+{{0xEF, 0x40, 0x15}, 24, 256, 32768, 0x52, 2097152, 3000, 1600000, "W25Q16JV*Q/W25Q16FV"},  // Winbond W25Q16JV*Q/W25Q16FV
+{{0xEF, 0x40, 0x16}, 24, 256, 32768, 0x52, 4194304, 3000, 1600000, "W25Q32JV*Q/W25Q32FV"},  // Winbond W25Q32JV*Q/W25Q32FV
+{{0xEF, 0x40, 0x17}, 24, 256, 65536, 0xD8, 8388608, 3000, 2000000, "W25Q64JV*Q/W25Q64FV"},  // Winbond W25Q64JV*Q/W25Q64FV
+{{0xEF, 0x40, 0x18}, 24, 256, 65536, 0xD8, 16777216, 3000, 2000000, "W25Q128JV*Q/W25Q128FV"}, // Winbond W25Q128JV*Q/W25Q128FV
+{{0xEF, 0x40, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, "W25Q256JV*Q"}, // Winbond W25Q256JV*Q
+{{0xEF, 0x40, 0x20}, 32, 256, 65536, 0xDC, 67108864, 3500, 2000000, "W25Q512JV*Q"}, // Winbond W25Q512JV*Q
+{{0xEF, 0x40, 0x21}, 32, 256, 65536, 0xDC, 134217728, 3500, 2000000, "W25Q01JV*Q"},// Winbond W25Q01JV*Q
+{{0xEF, 0x70, 0x17}, 24, 256, 65536, 0xD8, 8388608, 3000, 2000000, "W25Q64JV*M (DTR)"},  // Winbond W25Q64JV*M (DTR)
+{{0xEF, 0x70, 0x18}, 24, 256, 65536, 0xD8, 16777216, 3000, 2000000, "W25Q128JV*M (DTR)"}, // Winbond W25Q128JV*M (DTR)
+{{0xEF, 0x70, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, "W25Q256JV*M (DTR)"}, // Winbond W25Q256JV*M (DTR)
+{{0xEF, 0x80, 0x19}, 32, 256, 65536, 0xDC, 33554432, 3000, 2000000, "W25Q256JW*M"}, // Winbond (W25Q256JW*M)
+{{0xEF, 0x70, 0x20}, 32, 256, 65536, 0xDC, 67108864, 3500, 2000000, "W25Q512JV*M (DTR)"}, // Winbond W25Q512JV*M (DTR)
+{{0x1F, 0x84, 0x01}, 24, 256,  4096, 0x20, 524288, 2500, 300000, "AT25SF041"},    // Adesto/Atmel AT25SF041
+{{0x01, 0x40, 0x14}, 24, 256,  4096, 0x20, 1048576, 5000, 300000, "S25FL208K"},   // Spansion S25FL208K
 //FRAM
-{{0x03, 0x2E, 0xC2}, 24, 64, 128, 0, 1048576, 250, 1200, (const char*)F("CY15B108QN")}, //Cypress 8Mb FRAM, CY15B108QN
-{{0xC2, 0x24, 0x00}, 24, 64, 128, 0, 131072, 250, 1200, (const char*)F("FM25V10-G")},  //Cypress 1Mb FRAM, FM25V10-G
-{{0xC2, 0x24, 0x01}, 24, 64, 128, 0, 131072, 250, 1200, (const char*)F("FM25V10-G (rev 1)")},  //Cypress 1Mb FRAM, rev1
-{{0xAE, 0x83, 0x09}, 24, 64, 128, 0, 131072, 250, 1200, (const char*)F("MR45V100A")},  //ROHM MR45V100A 1 Mbit FeRAM Memory
-{{0xC2, 0x26, 0x08}, 24, 64, 128, 0, 524288, 250, 1200, (const char*)F("CY15B104Q")},  //Cypress 4Mb FRAM, CY15B104Q
-{{0x60, 0x2A, 0xC2}, 24, 64, 128, 0, 262144, 250, 1200, (const char*)F("CY15B102Q")},  //Cypress 2Mb FRAM, CY15B102Q
-{{0x60, 0x2A, 0xC2}, 24, 64, 128, 0, 262144, 250, 1200, (const char*)F("CY15B102Q")},  //Cypress 2Mb FRAM, CY15B102Q
-{{0x04, 0x7F, 0x48}, 24, 64, 128, 0, 262144, 250, 1200, (const char*)F("MB85RS2MTAPNF")},  //Fujitsu 2Mb FRAM, MB85RS2MTAPNF
+{{0x03, 0x2E, 0xC2}, 24, 64, 128, 0, 1048576, 250, 1200, "CY15B108QN"}, //Cypress 8Mb FRAM, CY15B108QN
+{{0xC2, 0x24, 0x00}, 24, 64, 128, 0, 131072, 250, 1200, "FM25V10-G"},  //Cypress 1Mb FRAM, FM25V10-G
+{{0xC2, 0x24, 0x01}, 24, 64, 128, 0, 131072, 250, 1200, "FM25V10-G (rev 1)"},  //Cypress 1Mb FRAM, rev1
+{{0xAE, 0x83, 0x09}, 24, 64, 128, 0, 131072, 250, 1200, "MR45V100A"},  //ROHM MR45V100A 1 Mbit FeRAM Memory
+{{0xC2, 0x26, 0x08}, 24, 64, 128, 0, 524288, 250, 1200, "CY15B104Q"},  //Cypress 4Mb FRAM, CY15B104Q
+{{0x60, 0x2A, 0xC2}, 24, 64, 128, 0, 262144, 250, 1200, "CY15B102Q"},  //Cypress 2Mb FRAM, CY15B102Q
+{{0x60, 0x2A, 0xC2}, 24, 64, 128, 0, 262144, 250, 1200, "CY15B102Q"},  //Cypress 2Mb FRAM, CY15B102Q
+{{0x04, 0x7F, 0x48}, 24, 64, 128, 0, 262144, 250, 1200, "MB85RS2MTAPNF"},  //Fujitsu 2Mb FRAM, MB85RS2MTAPNF
 
 };
 

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -418,11 +418,15 @@ public:
 	}
 	FLASHMEM
 	const char * getPN() {
+		PROGMEM static const char ram_pn_name[] = "MEMORY";
 #if defined(__IMXRT1062__)
-		if ((uint32_t)config.context >= 0x70000000) return (const char *)F("EXTMEM");
-		if ((uint32_t)config.context >= 0x20200000) return (const char *)F("DMAMEM");
+		PROGMEM static const char ext_pn_name[] = "EXTMEM";
+		PROGMEM static const char dma_pn_name[] = "DMAMEM";
+
+		if ((uint32_t)config.context >= 0x70000000) return ext_pn_name;
+		if ((uint32_t)config.context >= 0x20200000) return dma_pn_name;
 #endif
-		return (const char *)F("MEMORY");
+		return ram_pn_name;
 	}
 private:
 	static int static_read(const struct lfs_config *c, lfs_block_t block,
@@ -581,7 +585,10 @@ class LittleFS_Program : public LittleFS
 public:
 	LittleFS_Program() { }
 	bool begin(uint32_t size);
-	const char * getPN() { return (const char *)F("PROGRAM"); }
+	const char * getPN() { 
+		PROGMEM static const char pn_name[] = "PROGRAM";
+		return pn_name; 
+	}
 private:
 	static int static_read(const struct lfs_config *c, lfs_block_t block,
 	  lfs_off_t offset, void *buffer, lfs_size_t size);

--- a/src/LittleFS_NAND.cpp
+++ b/src/LittleFS_NAND.cpp
@@ -74,16 +74,16 @@ PROGMEM static const struct chipinfo {
 	uint32_t chipsize;	// total number of bytes in the chip
 	uint32_t progtime;	// maximum microseconds to wait for page programming
 	uint32_t erasetime;	// maximum microseconds to wait for sector erase
-	const char *pn;		//flash name
+	const char pn[14];		//flash name
 } known_chips[] = {
 	//NAND
 	//{{0xEF, 0xAA, 0x21}, 24, 2048, 131072, 134217728,   2000, 15000},  //Winbond W25N01G
 	//Upper 24 blocks * 128KB/block will be used for bad block replacement area
 	//so reducing total chip size: 134217728 - 24*131072
-    {{0xEF, 0xAA, 0x21}, 24, 2048, 131072, 0, 131596288, 2000, 15000, (const char*)F("W25N01GVZEIG")},  //Winbond W25N01G
+    {{0xEF, 0xAA, 0x21}, 24, 2048, 131072, 0, 131596288, 2000, 15000, "W25N01GVZEIG"},  //Winbond W25N01G
 	//{{0xEF, 0xAA, 0x22}, 24, 2048, 131072, 134217728*2, 2000, 15000},  //Winbond W25N02G
-	{{0xEF, 0xAA, 0x22}, 24, 2048, 131072, 0, 265289728, 2000, 15000, (const char*)F("W25N02KVZEIR")},  //Winbond W25N02G
-    {{0xEF, 0xBB, 0x21}, 24, 2048, 131072, 0, 265289728, 2000, 15000, (const char*)F("W25M02")},  //Winbond W25M02
+	{{0xEF, 0xAA, 0x22}, 24, 2048, 131072, 0, 265289728, 2000, 15000, "W25N02KVZEIR"},  //Winbond W25N02G
+    {{0xEF, 0xBB, 0x21}, 24, 2048, 131072, 0, 265289728, 2000, 15000, "W25M02"},  //Winbond W25M02
 };
 
 volatile uint32_t currentPage     = UINT32_MAX;


### PR DESCRIPTION
Updated those in tables and some hard coded ones
@mjs513 - I think this appears to work and keep strings out of dtcm